### PR TITLE
Create and Test get_user_type Function for User Role Management

### DIFF
--- a/land_registry/src/interface/land_register.cairo
+++ b/land_registry/src/interface/land_register.cairo
@@ -94,6 +94,8 @@ pub trait ILandRegistry<TContractState> {
     fn set_fee(ref self: TContractState, fee: u128);
     fn get_fee(self: @TContractState) -> u128;
 
+    fn get_user_type(self: @TContractState, userAddress: ContractAddress) -> felt252;
+
     // Marketplace function
     fn create_listing(ref self: TContractState, land_id: u256, price: u256) -> u256;
     fn cancel_listing(ref self: TContractState, listing_id: u256);

--- a/land_registry/src/land_register.cairo
+++ b/land_registry/src/land_register.cairo
@@ -180,27 +180,21 @@ pub mod LandRegistryContract {
 
             land_id
         }
-        fn get_user_type(self: @ContractState, userAddress: ContractAddress)-> felt252 { 
-      
-        let inspector = self.registered_inspectors.read(userAddress);
-      
-        let owner = self.owner_land_count.read(userAddress);
-        let inspector_role = 'inspector';
-        let owner_role = 'owner';
+        fn get_user_type(self: @ContractState, userAddress: ContractAddress) -> felt252 {
+            let inspector = self.registered_inspectors.read(userAddress);
 
-        if inspector {
+            let owner = self.owner_land_count.read(userAddress);
+            let inspector_role = 'inspector';
+            let owner_role = 'owner';
 
-            return inspector_role;
+            if inspector {
+                return inspector_role;
+            } else if (owner > 0) {
+                return owner_role;
+            } else {
+                return 'None';
+            }
         }
-        else if (owner>0)
-        {
-            return owner_role;
-        }
-        else{
-            return 'None';
-        }
-
-    }
 
         fn get_land(self: @ContractState, land_id: u256) -> Land {
             self.lands.read(land_id)
@@ -639,7 +633,4 @@ pub mod LandRegistryContract {
 
         return false;
     }
-
-
-    
 }

--- a/land_registry/src/land_register.cairo
+++ b/land_registry/src/land_register.cairo
@@ -608,4 +608,37 @@ pub mod LandRegistryContract {
             }
         }
     }
+
+    fn is_inspector(self: @ContractState, inspector: ContractAddress) -> bool {
+        let count = self.lands_assigned_to_inspector.read(inspector);
+
+        if count > 0 {
+            return true;
+        }
+
+        return false;
+    }
+
+
+    fn get_user_type(self: @ContractState, userAddress: ContractAddress)-> felt252 { 
+        // checking if a user has been registered on 
+        let inspector = self.registered_inspectors.read(userAddress);
+        // Reading the number of number of lands owned by an owner 
+        let owner = self.owner_land_count.read(userAddress);
+        let inspector_role = 'inspector';
+        let owner_role = 'owner';
+
+        if inspector {
+
+            return inspector_role;
+        }
+        else if (owner>0)
+        {
+            return owner_role;
+        }
+        else{
+            return 'Note a user on this plateform';
+        }
+
+    }
 }

--- a/land_registry/src/land_register.cairo
+++ b/land_registry/src/land_register.cairo
@@ -180,6 +180,27 @@ pub mod LandRegistryContract {
 
             land_id
         }
+        fn get_user_type(self: @ContractState, userAddress: ContractAddress)-> felt252 { 
+      
+        let inspector = self.registered_inspectors.read(userAddress);
+      
+        let owner = self.owner_land_count.read(userAddress);
+        let inspector_role = 'inspector';
+        let owner_role = 'owner';
+
+        if inspector {
+
+            return inspector_role;
+        }
+        else if (owner>0)
+        {
+            return owner_role;
+        }
+        else{
+            return 'None';
+        }
+
+    }
 
         fn get_land(self: @ContractState, land_id: u256) -> Land {
             self.lands.read(land_id)
@@ -620,25 +641,5 @@ pub mod LandRegistryContract {
     }
 
 
-    fn get_user_type(self: @ContractState, userAddress: ContractAddress)-> felt252 { 
-        // checking if a user has been registered on 
-        let inspector = self.registered_inspectors.read(userAddress);
-        // Reading the number of number of lands owned by an owner 
-        let owner = self.owner_land_count.read(userAddress);
-        let inspector_role = 'inspector';
-        let owner_role = 'owner';
-
-        if inspector {
-
-            return inspector_role;
-        }
-        else if (owner>0)
-        {
-            return owner_role;
-        }
-        else{
-            return 'Note a user on this plateform';
-        }
-
-    }
+    
 }

--- a/land_registry/tests/test_land_register.cairo
+++ b/land_registry/tests/test_land_register.cairo
@@ -857,22 +857,13 @@ fn test_get_user_type() {
     stop_cheat_caller_address(contract_address);
 
     let owner_type = land_register_dispatcher.get_user_type(owner_address);
-    assert(
-        owner_type == 'owner',
-        'Expect Owner'
-    );
+    assert(owner_type == 'owner', 'Expect Owner');
 
     let inspector_type = land_register_dispatcher.get_user_type(inspector_address);
-    assert(
-        inspector_type == 'inspector',
-        'Expect Inspector'
-    );
+    assert(inspector_type == 'inspector', 'Expect Inspector');
 
     // Check a non-existent user
     let non_existent_address = starknet::contract_address_const::<0x789>();
     let non_user_type = land_register_dispatcher.get_user_type(non_existent_address);
-    assert(
-        non_user_type == 'None',
-        'Expecte None'
-    );
+    assert(non_user_type == 'None', 'Expecte None');
 }


### PR DESCRIPTION
## Detailed Information

This PR introduces a new function called get_user_type that receives a user address as input and returns the user's role as a string (e.g., "owner", "inspector", "None"). This functionality streamlines role management for improved user experience.

Input: User address
Output: User role as a string (e.g., "owner", "inspector", "None")

## Related Issues

Closes #<issue-number>

---

## Type of Change

- [ ] 🐛 Bug fix or ⚙️ enhancement
-✅ ✨ New feature or Chore (change with no new features or fixes)
- [ ] 📚 Documentation update

---

## Checklist (select as many as applicable)

✅ The code follows the style guidelines of this project.
✅  All new and existing tests pass.
✅  This pull request is ready to be merged and reviewed.
