### PR TITLE
feat: add build checks for app/client and landing page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,35 @@ jobs:
       - name: Run tests
         run: snforge test
         working-directory: land_registry
+
+  build-client:
+    runs-on: ubuntu-latest
+    name: Build app/client and landing page
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18  # Use the version required by your project
+
+      - name: Cache Node.js modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: app/client
+
+      - name: Build app/client
+        run: npm run build
+        working-directory: app/client
+
+      - name: Build landing page
+        run: npm run build-landing-page  # Replace with the actual command for building the landing page
+        working-directory: app/client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     name: tests
     steps:
       - name: Checkout code
-        uses: actions/checkout@main
+        uses: actions/checkout@v3
 
       - name: Set up Scarb
         uses: software-mansion/setup-scarb@v1
@@ -56,7 +56,7 @@ jobs:
     name: Build app/client and landing page
     steps:
       - name: Checkout code
-        uses: actions/checkout@main
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -71,7 +71,7 @@ jobs:
           restore-keys: |
             npm-${{ runner.os }}-
 
-      - name: Install dependencies
+      - name: Install dependencies for client
         run: npm install
         working-directory: app/client
 
@@ -79,6 +79,10 @@ jobs:
         run: npm run build
         working-directory: app/client
 
+      - name: Install dependencies for landing page
+        run: npm install
+        working-directory: landing_page
+
       - name: Build landing page
-        run: npm run build-landing-page  # Replace with the actual command for building the landing page
-        working-directory: app/client
+        run: npm run build
+        working-directory: landing_page

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,13 +63,13 @@ jobs:
         with:
           node-version: 20  # Use the version required by your project
 
-      - name: Cache Node.js modules
+      - name: Cache pnpm modules
         uses: actions/cache@v3
         with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.pnpm-store
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            npm-${{ runner.os }}-
+            pnpm-${{ runner.os }}-
 
       - name: Install dependencies for client
         run: pnpm install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18  # Use the version required by your project
+          node-version: 20  # Use the version required by your project
 
       - name: Cache Node.js modules
         uses: actions/cache@v3
@@ -72,7 +72,7 @@ jobs:
             npm-${{ runner.os }}-
 
       - name: Install dependencies for client
-        run: npm install
+        run: pnpm install
         working-directory: app/client
 
       - name: Build app/client


### PR DESCRIPTION
Description

This PR modifies the workflow to check for build errors in the `app/client` and landing page, in addition to the existing contract tests. The changes ensure that the CI/CD pipeline fails if any build errors occur, improving the reliability of the deployment process.

 Changes
- Added a new job (`build-client`) to the GitHub Actions workflow.
- The `build-client` job:
  - Sets up Node.js and installs dependencies for `app/client`.
  - Builds the `app/client` using `npm run build`.
  - Builds the landing page using `npm run build-landing-page`.
- Updated the `package.json` to include the `build-landing-page` script.

 Related Issues
Closes #<issue-number>

 Type of Change
- [x] 🐛 Bug fix or ⚙️ enhancement
- [ ] ✨ New feature or Chore (change with no new features or fixes)
- [ ] 📚 Documentation update

 Testing
- Verified that the workflow runs successfully in GitHub Actions.
- Manually tested the `app/client` and landing page builds locally.
- Confirmed that the workflow fails if build errors are introduced.

