### PR TITLE
Prevent Duplicate Role Registration in Smart Contracts

### DIFF
--- a/contracts/land_registry/src/custom_error.cairo
+++ b/contracts/land_registry/src/custom_error.cairo
@@ -16,6 +16,8 @@ pub mod Errors {
     pub const OWNER_MK_INSPECTOR: felt252 = 'Only owner can set an inspector';
     pub const INSPECTOR_ADDR: felt252 = 'Invalid inspector address';
     pub const REGISTERED_INSPECTOR: felt252 = 'Inspector already registered';
+    pub const REGISTERED_OWNER: felt252 = 'Owner already registered';
+    pub const ALREADY_REGISTERED_FOR_ROLE: felt252 = 'Already registered for role';
     pub const NOT_REGISTERED_INSP: felt252 = 'Inspector not registered';
     pub const ACTIVE_INSPECTOR: felt252 = 'Inspector is active';
     pub const NOT_AUTHORIZED: felt252 = 'Not authorized';

--- a/contracts/land_registry/src/land_register.cairo
+++ b/contracts/land_registry/src/land_register.cairo
@@ -218,7 +218,7 @@ pub mod LandRegistryContract {
             let mut result = array![];
             let owner_land_count = self.owner_land_count.read(owner);
             let mut i = 0;
-            while i < owner_land_count {
+            while i != owner_land_count {
                 let land_id = self.owner_lands.read((owner, i));
                 result.append(land_id);
                 i += 1;
@@ -231,7 +231,7 @@ pub mod LandRegistryContract {
             let land_count = self.land_count.read();
             let mut i: u64 = 1;
 
-            while i < land_count + 1 {
+            while i != land_count + 1 {
                 let land: Land = self.lands_registry.read(i);
                 lands.append(land);
                 i += 1;
@@ -374,8 +374,9 @@ pub mod LandRegistryContract {
             let mut pending_approvals = array![];
             let owner = get_caller_address();
             let owner_land_count = self.owner_land_count.read(owner);
+            
             let mut i = 0;
-            while i < owner_land_count {
+            while i != owner_land_count {
                 let land_id = self.owner_lands.read((owner, i));
                 if (!self.approved_lands.read(land_id)) {
                     pending_approvals.append(land_id);
@@ -391,7 +392,7 @@ pub mod LandRegistryContract {
             let mut land_history = array![];
             let transaction_count = self.land_transaction_count.read(land_id);
             let mut i = 0;
-            while i < transaction_count {
+            while i != transaction_count {
                 land_history.append(self.land_transaction_history.read((land_id, i)));
                 i += 1;
             };
@@ -424,7 +425,7 @@ pub mod LandRegistryContract {
             let land_count = self.land_count.read();
             let mut i: u64 = 1;
 
-            while i < land_count + 1 {
+            while i != land_count + 1 {
                 let land_registry: Land = self.lands_registry.read(i);
                 let land_inspector = self.land_inspectors.read(land_registry.land_id);
 
@@ -479,7 +480,7 @@ pub mod LandRegistryContract {
             let mut inspectors = array![];
             let inspector_count = self.inspector_count.read();
             let mut i = 0;
-            while i < inspector_count {
+            while i != inspector_count {
                 let inspector = self.all_land_inspectors.read(i);
                 if (self.registered_inspectors.read(inspector)) {
                     inspectors.append(inspector);
@@ -628,7 +629,7 @@ pub mod LandRegistryContract {
             let count = self.active_listing_count.read();
 
             let mut i: u64 = 0;
-            while i < count {
+            while i != count {
                 active.append(self.active_listings.read(i));
                 i += 1;
             };
@@ -660,7 +661,7 @@ pub mod LandRegistryContract {
             let mut i: u64 = 0;
 
             // Find listing index
-            while i < count {
+            while i != count {
                 if self.active_listings.read(i) == listing_id {
                     // Replace with last listing if not last
                     if i < count - 1 {


### PR DESCRIPTION
## Detailed Information

The original issue was to prevent duplicate role registrations (e.g., registering as Inspector multiple times with the same wallet). The contract already had checks in place to prevent duplicate Inspector registrations, so that part was essentially fixed.

### What’s Changed

**Role Exclusivity:**
- I added logic to enforce the fact that a wallet address can only have one role at a time.
- If a user is already an Inspector, they cannot register land (become a Land Owner).
= If a user already owns land, they cannot register as an Inspector.

**New Error Message:**
- Added a specific revert message (Already registered for role) for attempts to register for a new role when already assigned another.

**Tests:**
- Added new tests to ensure users cannot register for a second role if they already have one.

**Cairo Optimization:**
- Replaced all while i < count loops with while i != count for better Cairo performance, (IDE suggestion; made sure that business logic doesn't change in any of them)

---

## Related Issues

Closes #357 

---

## Type of Change

- [x] 🐛 Bug fix or ⚙️ enhancement
- [ ] ✨ New feature or Chore (change with no new features or fixes)
- [ ] 📚 Documentation update

---

## Checklist (select as many as applicable)

- [ ] The code follows the style guidelines of this project.
- [ ] All new and existing tests pass.
- [ ] This pull request is ready to be merged and reviewed.
