### PR TITLE
Restrict dashboard access based on user role

### DIFF
--- a/land-registry-backend/src/middleware/roleGuard.ts
+++ b/land-registry-backend/src/middleware/roleGuard.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * Middleware to restrict access to routes based on user role.
+ * Usage: app.use('/dashboard/owner', roleGuard(['owner']), ...)
+ */
+export function roleGuard(allowedRoles: string[]) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // Assumes req.user is set by authentication middleware (e.g., JWT)
+    const userRole = req.user?.role;
+    if (!userRole || !allowedRoles.includes(userRole)) {
+      return res.status(403).json({ message: "Forbidden: Insufficient role" });
+    }
+    next();
+  };
+}


### PR DESCRIPTION
- Add roleGuard middleware to enforce role-based access control on dashboard routes
- Users can only access dashboard routes matching their assigned role
- Returns 403 Forbidden for unauthorized access attempts

Closes #362

## Detailed Information

---

## Related Issues

Closes #<issue-number>

---

## Type of Change

- [ ] 🐛 Bug fix or ⚙️ enhancement
- [ ] ✨ New feature or Chore (change with no new features or fixes)
- [ ] 📚 Documentation update

---

## Checklist (select as many as applicable)

- [ ] The code follows the style guidelines of this project.
- [ ] All new and existing tests pass.
- [ ] This pull request is ready to be merged and reviewed.
